### PR TITLE
chore: add edlio- prefix for compatibility

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,6 +14,12 @@ function main () {
         console.error('Failed to detect window.customElements. Did you import webcomponents polyfill?');
         return;
     }
+    // Backward compatibility definition
+    window.customElements.define('edlio-accordion', AccordionComponent);
+    window.customElements.define('edlio-drawer', DrawerComponent);
+    window.customElements.define('edlio-modal', ModalComponent);
+    window.customElements.define('edlio-notification', NotificationComponent);
+    window.customElements.define('edlio-select', SelectComponent);
     window.customElements.define('uniform-accordion', AccordionComponent);
     window.customElements.define('uniform-drawer', DrawerComponent);
     window.customElements.define('uniform-example', ExampleComponent);

--- a/src/sass/components/_accordion.scss
+++ b/src/sass/components/_accordion.scss
@@ -1,7 +1,9 @@
 // COMPONENT : Accordion
 
 uniform-accordion,
-.uniform-accordion {
+.uniform-accordion,
+edlio-accordion,
+.edlio-accordion {
 	> section {
 		@extend %flexbox;
 		@include flex-direction(column);

--- a/src/sass/components/_drawers.scss
+++ b/src/sass/components/_drawers.scss
@@ -1,6 +1,7 @@
 // COMPONENT : Drawer
 
-uniform-drawer {
+uniform-drawer,
+edlio-drawer {
 
 	position: absolute;
 	z-index: $z-index-drawer;

--- a/src/sass/components/_modals.scss
+++ b/src/sass/components/_modals.scss
@@ -1,14 +1,17 @@
 // COMPONENT : Modals
 
 // Initially hide modal before overlay appears
-uniform-modal {
+uniform-modal,
+edlio-modal {
 	display: none;
 }
 
-uniform-overlay {
+uniform-overlay,
+edlio-overlay {
 	@extend %flexbox;
 	@include flex(1,0,100%);
 
+	uniform-modal,
 	uniform-modal {
 		@extend %flexbox;
 		@include flex(0,1,auto);

--- a/src/sass/components/_notifications.scss
+++ b/src/sass/components/_notifications.scss
@@ -25,7 +25,9 @@
 }
 
 uniform-notification,
-.uniform-notification {
+.uniform-notification,
+edlio-notification,
+.edlio-notification {
 	@extend %flexbox;
 	@include align-items(center);
 

--- a/src/sass/components/_overlays.scss
+++ b/src/sass/components/_overlays.scss
@@ -1,5 +1,7 @@
 uniform-overlay,
-.uniform-overlay {
+.uniform-overlay,
+edlio-overlay,
+.edlio-overlay {
 	position: absolute;
 	top: 0;
 	left: 0;

--- a/src/sass/components/_select-menus.scss
+++ b/src/sass/components/_select-menus.scss
@@ -1,7 +1,9 @@
 // COMPONENT : Select Menus
 
 uniform-select,
-.uniform-select {
+.uniform-select,
+edlio-select,
+.edlio-select {
 	position: relative;
 
 	display: inline-block;

--- a/src/sass/components/cms/_modals.scss
+++ b/src/sass/components/cms/_modals.scss
@@ -1,11 +1,13 @@
 @import 'components/modals';
 
-uniform-overlay {
+uniform-overlay,
+edlio-overlay {
 	@include justify-content(center);
 	@include align-items(center);
 	@include flex-flow(row wrap);
 
-	uniform-modal {
+	uniform-modal,
+	edlio-modal {
 		width: 100%;
 		height: 100%;
 		min-width: ($ui-min-width - ( 2 * $ui-gutter-mobile ));

--- a/src/sass/components/react/_modals.scss
+++ b/src/sass/components/react/_modals.scss
@@ -1,6 +1,7 @@
 // REACT COMPONENT : Modals
 
-.uniform-overlay {
+.uniform-overlay,
+.edlio-overlay {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -26,7 +27,8 @@
 
 	background-color: $overlay-color;
 
-	.uniform-modal {
+	.uniform-modal,
+	.edlio-modal {
 		@extend %flexbox;
 		@include flex(0,1,auto);
 		@include flex-direction(column);

--- a/src/sass/components/react/_timepickers.scss
+++ b/src/sass/components/react/_timepickers.scss
@@ -83,7 +83,9 @@
     }
 
     uniform-select,
-    .uniform-select {
+    .uniform-select,
+    edlio-select,
+    .edlio-select {
       margin: 0;
       box-shadow: 
         inset -1px 0 0 0 $textfield-border-color,

--- a/src/sass/libraries/mixins/_typography.scss
+++ b/src/sass/libraries/mixins/_typography.scss
@@ -454,7 +454,9 @@
 		// Notifications -----------------------------------------------------------
 
 		uniform-notification,
-		.uniform-notification {
+		.uniform-notification,
+		edlio-notification,
+		.edlio-notification {
 			min-height: ($line-height-multiplier * $line-height);
 			margin: {
 				bottom: $line-height;
@@ -472,7 +474,9 @@
 		}
 
 		uniform-select,
-		.uniform-select {
+		.uniform-select,
+		edlio-select,
+		.edlio-select {
 			margin: {
 				right: .618 * ((($line-height-multiplier * $line-height) - ( 1rem * $icon-size-multiplier )) / 2 );
 				bottom: $line-height;
@@ -546,7 +550,9 @@
 		// Accordions --------------------------------------------------------------
 
 		uniform-accordion,
-		.uniform-accordion {
+		.uniform-accordion,
+		edlio-accordion,
+		.edlio-accordion {
 			header {
 				line-height: ($line-height-multiplier * $line-height);
 			}


### PR DESCRIPTION
# Context

This PR adds the "edlio-" prefix back for the uniform components. So uniform components can work on both "uniform-" prefix as well as "edlio-" prefix.