### PR TITLE
Re-open Modal

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -157,7 +157,7 @@ export default class ModalComponent extends window.HTMLElement {
             this.style.webkitTransform = '';
             this.style.transform = '';
             // reset scrolling event
-            document.body.style.overflow = "visible";
+            document.body.style.overflow = null;
 
             document.body.appendChild(this);
             this.container.remove();

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -157,7 +157,9 @@ export default class ModalComponent extends window.HTMLElement {
             this.style.webkitTransform = '';
             this.style.transform = '';
             // reset scrolling event
-            document.body.style.overflow = undefined;
+            document.body.style.overflow = "visible";
+
+            document.body.appendChild(this);
             this.container.remove();
 
             if (this.removeOnHide) {
@@ -168,7 +170,6 @@ export default class ModalComponent extends window.HTMLElement {
     }
 
     connectedCallback () {
-        console.log(this.parentNode);
         this.previousParent = this.parentNode;
     }
 };


### PR DESCRIPTION
## What was happening
- On `show` the `document.body` was being supplied an inline-style of `overflow: hidden` and on `hide` the style was being set to `undefined`
- On `hide` the `simple-modal` node was being removed, causing a call to `open` on a null node.

## How it was fixed
- Instead of setting `overflow` to `undefined` I set it to the default value of `visible`
- Appended the `simple-modal` node back to the `document.body` before having it and its container removed.

## Issue
#16 