### PR TITLE
kitchen sink data table provide datetime format example

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1119,7 +1119,7 @@
                         <header class="thead">
                             <div class="th">
                                 <div class="column">
-                                    Time <svg class="active icon">
+                                    DateTime <svg class="active icon">
                                         <use xlink:href="#caret-down"></use>
                                     </svg>
                                 </div>
@@ -1138,8 +1138,8 @@
                         </header>
                         <div class="tbody">
                             <div class="tr border">
-                                <div class="column">
-                                    Today
+                                <div class="column" title="Fri Apr 27 2018 11:07:00 GMT-0700 (Pacific Daylight Time)">
+                                    Apr 27th, 2018 11:07 am
                                 </div>
                                 <div class="column">
                                     <a href="#">Eric</a>
@@ -1157,8 +1157,8 @@
                                 </div>
                             </div>
                             <div class="tr border">
-                                <div class="column">
-                                    Yesterday
+                                <div class="column" title="Tue May 01 2018 13:37:00 GMT-0700 (Pacific Daylight Time)">
+                                    May 1st, 2018 1:37 pm
                                 </div>
                                 <div class="column">
                                     <a href="#">Eric</a>
@@ -1188,8 +1188,8 @@
                                 </div>
                             </div>
                             <div class="tr border">
-                                <div class="column">
-                                    A week ago
+                                <div class="column" title="Mon Dec 25 2017 12:02:00 GMT-0800 (Pacific Standard Time)">
+                                    Jun 3rd, 2018 6:57 pm
                                 </div>
                                 <div class="column">
                                     Eric
@@ -1258,8 +1258,8 @@
                                 </div>
                             </div>
                             <div class="disabled tr border">
-                                <div class="column">
-                                    Yesterday
+                                <div class="column" title="Mon Dec 25 2017 12:02:00 GMT-0800 (Pacific Standard Time)">
+                                    Dec 25th, 2017 12:02 am
                                 </div>
                                 <div class="column">
                                     <a href="#">Eric</a>


### PR DESCRIPTION
kitchen sink data table provide datetime format example:
**Apr 27th, 2018 11:07 am**
with tooltip: 
**Tue May 01 2018 13:37:00 GMT-0700 (Pacific Daylight Time)**


This is now the standard datetime format to be used across cms.

**_tooltip format is not final and can be updated._** 
the idea is to use tooltip to provide full information including date, time and timezone.