### PR TITLE
placeholder selector fixed

### DIFF
--- a/src/sass/components/_forms.scss
+++ b/src/sass/components/_forms.scss
@@ -45,15 +45,29 @@ input {
 		// iOS Overrides
 		-webkit-appearance: none;
 		-webkit-border-radius: 0;
-	  border-radius: 0;
+	  	border-radius: 0;
 
 		// Placeholders
-		&::-webkit-input-placeholder,
-		&:-moz-placeholder,
-		&::-moz-placeholder,
-		&:-ms-input-placeholder {
+		// comma separated selectors do not work with placeholder.
+		// https://stackoverflow.com/questions/44971077/why-do-comma-separated-placeholder-rules-not-get-applied-in-css
+
+		&::-webkit-input-placeholder{
+			color: $textfield-placeholder-color;
 			font-family: $textfield-font-family;
-		  color: $textfield-placeholder-color;
+		}
+		&::-moz-placeholder{
+			color: $textfield-placeholder-color;
+			font-family: $textfield-font-family;
+			opacity:1;
+		}
+
+		&::-ms-input-placeholder{
+			color: $textfield-placeholder-color;
+			font-family: $textfield-font-family;
+		}
+		&::placeholder {
+			color: $textfield-placeholder-color;
+			font-family: $textfield-font-family;
 		}
 	}
 
@@ -295,12 +309,24 @@ textarea {
 	box-shadow: inset 0 0 0 $default-border-width $textarea-border-color;
 	outline: none;
 
-	&::-webkit-input-placeholder,
-	&:-moz-placeholder,
-	&::-moz-placeholder,
-	&:-ms-input-placeholder {
+	// comma separated selectors do not work with placeholder.
+	// https://stackoverflow.com/questions/44971077/why-do-comma-separated-placeholder-rules-not-get-applied-in-css
+	&::-webkit-input-placeholder{
+		color: $textarea-placeholder-color;
 		font-family: $textarea-font-family;
-	  color: $textarea-placeholder-color;
+	}
+	&::-moz-placeholder{
+		color: $textarea-placeholder-color;
+		font-family: $textarea-font-family;
+		opacity:1;
+	}
+	&::-ms-input-placeholder{
+		color: $textarea-placeholder-color;
+		font-family: $textarea-font-family;
+	}
+	&::placeholder {
+		color: $textarea-placeholder-color;
+		font-family: $textarea-font-family;
 	}
 }
 

--- a/src/sass/themes/_default.scss
+++ b/src/sass/themes/_default.scss
@@ -93,7 +93,7 @@ $label-text-color                   : $grey-n07   !default;
 
 $textfield-bg-color                 : $white      !default;
 $textfield-border-color             : $grey-n03   !default;
-$textfield-placeholder-color        : $grey-n05   !default;
+$textfield-placeholder-color        : $grey-n04   !default;
 $textfield-text-color               : $grey-n06   !default;
 
 // Special textfield overrides
@@ -103,7 +103,7 @@ $textfield-font-style               : normal       !default;
 
 $textarea-bg-color                  : $white       !default;
 $textarea-border-color              : $grey-n03    !default;
-$textarea-placeholder-color         : $grey-n05    !default;
+$textarea-placeholder-color         : $grey-n04    !default;
 $textarea-text-color                : $grey-n06    !default;
 
 // Special textarea overrides

--- a/src/sass/themes/cms/_edlio.scss
+++ b/src/sass/themes/cms/_edlio.scss
@@ -91,7 +91,7 @@ $label-color                        : $grey-7;
 
 $textfield-bg-color                 : $body-bg-color;
 $textfield-border-color             : $grey-3;
-$textfield-placeholder-color        : $grey-5;
+$textfield-placeholder-color        : $grey-4;
 $textfield-text-color               : $grey-6;
 
 $textfield-icon-bg-color            : $grey-2;


### PR DESCRIPTION
issue #39
# Problem:
Input Placeholder styles were not working.
# Solution:
comma separated selectors do not work with placeholder.
https://stackoverflow.com/questions/44971077/why-do-comma-separated-placeholder-rules-not-get-applied-in-css

- palceholder color also dropped to lighter grey