### PR TITLE
Remove unnecessary double border-radius: 50%

### DIFF
--- a/src/sass/components/_cards.scss
+++ b/src/sass/components/_cards.scss
@@ -33,11 +33,11 @@
 		    margin-right: 1em;
 		    border-radius: 50%;
 		    background: $soft-black;
+		    overflow: hidden;
 
 		    img {
 		    	min-width: 4em;
 		    	height: 4em;
-		    	border-radius: 50%;
 		    }
 
 		    svg {


### PR DESCRIPTION
See code change. The double radius 50% was causing the edge of the image inside to be a little jagged. Makes more sense to just hide overflow on the container (.graphic) and remove the 50% border radius on the image itself.